### PR TITLE
adding Azure & GCP managed Postgres modules, dynamic cost estimation and region defaults

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,14 @@
-__pycache__/
-.env
+
+# Python
 venv/
+__pycache__/
+*.pyc
+
+# Terraform
+*.tfstate
+*.tfstate.*
+.terraform/
+.terraform.lock.hcl
+
+# Generated files
+codegen-api/generated/

--- a/codegen-api/main.py
+++ b/codegen-api/main.py
@@ -83,3 +83,7 @@ def form_post(
         "est_cost": est_cost,
         "default_region": default_region
     })
+
+@app.get("/", response_class=HTMLResponse)
+def form_get(request: Request):
+    return templates.TemplateResponse("index.html", {"request": request})

--- a/codegen-api/main.py
+++ b/codegen-api/main.py
@@ -3,14 +3,13 @@ from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from utils import generate_main_tf
 import json
-# optionally: from utils import commit_and_push
 
 app = FastAPI()
 templates = Jinja2Templates(directory="templates")
 
-@app.get("/", response_class=HTMLResponse)
-def form_get(request: Request):
-    return templates.TemplateResponse("index.html", {"request": request})
+# Load once at startup:
+pricing = json.load(open("pricing.json"))
+regions = json.load(open("regions.json"))
 
 @app.post("/generate", response_class=HTMLResponse)
 def form_post(
@@ -22,13 +21,13 @@ def form_post(
     db_identifier: str = Form(...)
 ):
     services = []
+
     if service_type == "container_orchestrator":
         services.append({
             "type": "container_orchestrator",
             "params": { "cluster_name": cluster_name }
         })
     elif service_type == "managed_postgres_db":
-        params = {}
         if cloud == "aws":
             params = {
                 "db_identifier": db_identifier,
@@ -39,7 +38,7 @@ def form_post(
         elif cloud == "azure":
             params = {
                 "db_name": db_identifier,
-                "resource_group_name": "my-resource-group",  # Could be dynamic
+                "resource_group_name": "my-resource-group",
                 "location": "eastus",
                 "admin_username": "admin",
                 "admin_password": "secret",
@@ -51,36 +50,36 @@ def form_post(
             }
         elif cloud == "gcp":
             params = {
-                "project_id": "my-gcp-project",  # Could be dynamic
+                "project_id": "my-gcp-project",
                 "db_name": db_identifier,
                 "region": "us-central1",
                 "tier": "db-custom-1-3840",
                 "admin_password": "secret",
                 "tags": {"Project": project_name}
             }
+        services.append({
+            "type": "managed_postgres_db",
+            "params": params
+        })
 
-    services.append({
-        "type": "managed_postgres_db",
-        "params": params
-    })
+    # dynamic cost & region logic block (should add api block for realtime processing ) ***
+    est_cost = sum(
+        pricing[cloud].get(s["type"], 0)
+        for s in services
+    )
+    default_region = regions[cloud][0]  # e.g., "us-east-1"
 
-
+    # Generate Terraform code
     user_input = {
         "cloud": cloud,
         "project_name": project_name,
         "services": services
     }
-
     tf_code = generate_main_tf(user_input)
 
-    # Optionally:
-    # commit_and_push(os.getcwd(), "infra", f"feat: add {service_type} on {cloud}")
-
-    return templates.TemplateResponse("result.html", {"request": request, "tf_code": tf_code})
-
-def load_json(filename):
-    with open(filename, 'r') as f:
-        return json.load(f)
-
-pricing = load_json("pricing.json")
-regions = load_json("regions.json")
+    return templates.TemplateResponse("result.html", {
+        "request": request,
+        "tf_code": tf_code,
+        "est_cost": est_cost,
+        "default_region": default_region
+    })

--- a/codegen-api/main.py
+++ b/codegen-api/main.py
@@ -1,20 +1,36 @@
-from fastapi import FastAPI
-from pydantic import BaseModel
+from fastapi import FastAPI, Form, Request
+from fastapi.responses import HTMLResponse
+from fastapi.templating import Jinja2Templates
 from utils import generate_main_tf
 
 app = FastAPI()
+templates = Jinja2Templates(directory="templates")
 
-class ServiceParams(BaseModel):
-    type: str
-    params: dict
+@app.get("/", response_class=HTMLResponse)
+def form_get(request: Request):
+    return templates.TemplateResponse("index.html", {"request": request})
 
-class BlueprintRequest(BaseModel):
-    cloud: str
-    project_name: str
-    services: list[ServiceParams]
-
-@app.post("/generate")
-def generate(req: BlueprintRequest):
-    user_input = req.dict()
-    result = generate_main_tf(user_input)
-    return result
+@app.post("/generate", response_class=HTMLResponse)
+def form_post(
+    request: Request,
+    cloud: str = Form(...),
+    project_name: str = Form(...),
+    cluster_name: str = Form(...),
+    db_identifier: str = Form(...)
+):
+    user_input = {
+        "cloud": cloud,
+        "project_name": project_name,
+        "services": [
+            {
+                "type": "container_orchestrator",
+                "params": { "cluster_name": cluster_name }
+            },
+            {
+                "type": "managed_postgres_db",
+                "params": { "db_identifier": db_identifier, "instance_class": "db.t3.medium", "username": "admin", "password": "secret" }
+            }
+        ]
+    }
+    tf_code = generate_main_tf(user_input)
+    return templates.TemplateResponse("result.html", {"request": request, "tf_code": tf_code})

--- a/codegen-api/main.py
+++ b/codegen-api/main.py
@@ -2,6 +2,7 @@ from fastapi import FastAPI, Form, Request
 from fastapi.responses import HTMLResponse
 from fastapi.templating import Jinja2Templates
 from utils import generate_main_tf
+# optionally: from utils import commit_and_push
 
 app = FastAPI()
 templates = Jinja2Templates(directory="templates")
@@ -15,22 +16,36 @@ def form_post(
     request: Request,
     cloud: str = Form(...),
     project_name: str = Form(...),
+    service_type: str = Form(...),
     cluster_name: str = Form(...),
     db_identifier: str = Form(...)
 ):
+    services = []
+    if service_type == "container_orchestrator":
+        services.append({
+            "type": "container_orchestrator",
+            "params": { "cluster_name": cluster_name }
+        })
+    elif service_type == "managed_postgres_db":
+        services.append({
+            "type": "managed_postgres_db",
+            "params": {
+                "db_identifier": db_identifier,
+                "instance_class": "db.t3.medium",
+                "username": "admin",
+                "password": "secret"
+            }
+        })
+
     user_input = {
         "cloud": cloud,
         "project_name": project_name,
-        "services": [
-            {
-                "type": "container_orchestrator",
-                "params": { "cluster_name": cluster_name }
-            },
-            {
-                "type": "managed_postgres_db",
-                "params": { "db_identifier": db_identifier, "instance_class": "db.t3.medium", "username": "admin", "password": "secret" }
-            }
-        ]
+        "services": services
     }
+
     tf_code = generate_main_tf(user_input)
+
+    # Optionally:
+    # commit_and_push(os.getcwd(), "infra", f"feat: add {service_type} on {cloud}")
+
     return templates.TemplateResponse("result.html", {"request": request, "tf_code": tf_code})

--- a/codegen-api/pricing.json
+++ b/codegen-api/pricing.json
@@ -1,0 +1,15 @@
+{
+    "aws": {
+      "ecs-ec2": 25,
+      "rds-postgres": 120
+    },
+    "azure": {
+      "aks": 30,
+      "postgres": 100
+    },
+    "gcp": {
+      "gke": 28,
+      "postgres": 90
+    }
+  }
+  

--- a/codegen-api/regions.json
+++ b/codegen-api/regions.json
@@ -1,0 +1,6 @@
+{
+    "aws": ["us-east-1", "us-west-2", "eu-central-1"],
+    "azure": ["eastus", "westeurope", "southeastasia"],
+    "gcp": ["us-central1", "europe-west1", "asia-southeast1"]
+  }
+  

--- a/codegen-api/requirements.txt
+++ b/codegen-api/requirements.txt
@@ -1,3 +1,4 @@
 fastapi
 uvicorn
 pydantic
+jinja2

--- a/codegen-api/requirements.txt
+++ b/codegen-api/requirements.txt
@@ -2,3 +2,4 @@ fastapi
 uvicorn
 pydantic
 jinja2
+gitpython

--- a/codegen-api/templates/index.html
+++ b/codegen-api/templates/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head><title>CloudCompose</title></head>
+<body>
+  <h2>🛠 CloudCompose</h2>
+  <form method="post" action="/generate">
+    Cloud: <input name="cloud" value="aws"><br>
+    Project name: <input name="project_name" value="demo-app"><br>
+    <p>Example params:</p>
+    Cluster name: <input name="cluster_name" value="my-ecs-cluster"><br>
+    DB identifier: <input name="db_identifier" value="mydb"><br>
+    <button type="submit">Generate Terraform</button>
+  </form>
+</body>
+</html>

--- a/codegen-api/templates/index.html
+++ b/codegen-api/templates/index.html
@@ -1,15 +1,46 @@
 <!DOCTYPE html>
 <html>
-<head><title>CloudCompose</title></head>
+<head>
+  <title>CloudCompose</title>
+  <style>
+    body { font-family: sans-serif; margin: 40px; }
+    h2 { color: #2d6cdf; }
+    select, input, button { margin: 5px; padding: 5px; }
+    .section { margin-bottom: 20px; }
+  </style>
+</head>
 <body>
-  <h2>🛠 CloudCompose</h2>
+  <h2>🛠 CloudCompose – Multi‑Cloud Infra Generator</h2>
   <form method="post" action="/generate">
-    Cloud: <input name="cloud" value="aws"><br>
-    Project name: <input name="project_name" value="demo-app"><br>
-    <p>Example params:</p>
-    Cluster name: <input name="cluster_name" value="my-ecs-cluster"><br>
-    DB identifier: <input name="db_identifier" value="mydb"><br>
-    <button type="submit">Generate Terraform</button>
+    <div class="section">
+      <label>🌩 Choose Cloud Platform:</label>
+      <select name="cloud">
+        <option value="aws">AWS</option>
+        <option value="azure">Azure</option>
+        <option value="gcp">GCP</option>
+      </select>
+    </div>
+
+    <div class="section">
+      <label>📦 Choose Service:</label>
+      <select name="service_type">
+        <option value="container_orchestrator">Container Orchestrator (ECS / AKS / GKE)</option>
+        <option value="managed_postgres_db">Managed Postgres DB</option>
+      </select>
+    </div>
+
+    <div class="section">
+      <label>📝 Project Name:</label>
+      <input name="project_name" value="demo-app">
+    </div>
+
+    <div class="section">
+      <label>🔧 Service Params:</label><br>
+      Cluster Name: <input name="cluster_name" value="demo-cluster"><br>
+      DB Identifier: <input name="db_identifier" value="mydb">
+    </div>
+
+    <button type="submit">🚀 Generate Terraform Code</button>
   </form>
 </body>
 </html>

--- a/codegen-api/templates/result.html
+++ b/codegen-api/templates/result.html
@@ -3,6 +3,8 @@
 <head><title>Generated Terraform</title></head>
 <body>
   <h2>✅ Generated Terraform Code</h2>
+  <p><strong>Estimated monthly cost:</strong> ${{ est_cost }}</p>
+  <p><strong>Default deployment region:</strong> {{ default_region }}</p>
   <pre>{{ tf_code }}</pre>
   <a href="/">← Back</a>
 </body>

--- a/codegen-api/templates/result.html
+++ b/codegen-api/templates/result.html
@@ -1,0 +1,9 @@
+<!DOCTYPE html>
+<html>
+<head><title>Generated Terraform</title></head>
+<body>
+  <h2>✅ Generated Terraform Code</h2>
+  <pre>{{ tf_code }}</pre>
+  <a href="/">← Back</a>
+</body>
+</html>

--- a/service-catalog/azure/aks/README.md
+++ b/service-catalog/azure/aks/README.md
@@ -1,0 +1,4 @@
+
+# AWS ECS-EC2 Wrapper Module
+This module wraps [terraform-aws-modules/ecs/aws](https://registry.terraform.io/modules/terraform-aws-modules/ecs/aws)
+Adds org tags & defaults for use in CloudCompose.

--- a/service-catalog/azure/aks/main.tf
+++ b/service-catalog/azure/aks/main.tf
@@ -1,0 +1,16 @@
+module "aks" {
+  source  = "Azure/aks/azurerm"
+  version = "9.0.0"
+
+  resource_group_name = var.resource_group_name
+  kubernetes_version  = var.kubernetes_version
+  prefix              = var.cluster_name
+
+  default_node_pool = {
+    name       = "default"
+    node_count = var.node_count
+    vm_size    = var.node_vm_size
+  }
+
+  tags = var.tags
+}

--- a/service-catalog/azure/aks/outputs.tf
+++ b/service-catalog/azure/aks/outputs.tf
@@ -1,0 +1,3 @@
+output "cluster_id" {
+  value = module.ecs.id
+}

--- a/service-catalog/azure/aks/postgres/main.tf
+++ b/service-catalog/azure/aks/postgres/main.tf
@@ -1,0 +1,16 @@
+module "postgres" {
+  source  = "Azure/postgresql/azurerm"
+  version = "4.7.0"
+
+  name                = var.db_name
+  resource_group_name  = var.resource_group_name
+  location            = var.location
+  administrator_login = var.admin_username
+  administrator_password = var.admin_password
+  sku_name            = var.sku_name
+  storage_mb          = var.storage_mb
+  backup_retention_days = var.backup_retention_days
+  geo_redundant_backup = var.geo_redundant_backup
+
+  tags = var.tags
+}

--- a/service-catalog/azure/aks/postgres/variables.tf
+++ b/service-catalog/azure/aks/postgres/variables.tf
@@ -1,0 +1,10 @@
+variable "db_name" {}
+variable "resource_group_name" {}
+variable "location" {}
+variable "admin_username" {}
+variable "admin_password" {}
+variable "sku_name" { default = "GP_Gen5_2" }
+variable "storage_mb" { default = 5120 }
+variable "backup_retention_days" { default = 7 }
+variable "geo_redundant_backup" { default = "Disabled" }
+variable "tags" { type = map(string) }

--- a/service-catalog/azure/aks/variables.tf
+++ b/service-catalog/azure/aks/variables.tf
@@ -1,0 +1,6 @@
+variable "resource_group_name" {}
+variable "kubernetes_version" {}
+variable "cluster_name" {}
+variable "node_count" { default = 1 }
+variable "node_vm_size" { default = "Standard_DS2_v2" }
+variable "tags" { type = map(string) }

--- a/service-catalog/gcp/gke/README.md
+++ b/service-catalog/gcp/gke/README.md
@@ -1,0 +1,4 @@
+
+# AWS ECS-EC2 Wrapper Module
+This module wraps [terraform-aws-modules/ecs/aws](https://registry.terraform.io/modules/terraform-aws-modules/ecs/aws)
+Adds org tags & defaults for use in CloudCompose.

--- a/service-catalog/gcp/gke/main.tf
+++ b/service-catalog/gcp/gke/main.tf
@@ -1,0 +1,13 @@
+module "gke" {
+  source  = "terraform-google-modules/kubernetes-engine/google"
+  version = "25.0.0"
+
+  project_id     = var.project_id
+  name           = var.cluster_name
+  region         = var.region
+  network        = var.network
+  subnetwork     = var.subnetwork
+  initial_node_count = var.node_count
+
+  tags = var.tags
+}

--- a/service-catalog/gcp/gke/outputs.tf
+++ b/service-catalog/gcp/gke/outputs.tf
@@ -1,0 +1,3 @@
+output "cluster_id" {
+  value = module.ecs.id
+}

--- a/service-catalog/gcp/gke/variables.tf
+++ b/service-catalog/gcp/gke/variables.tf
@@ -1,0 +1,7 @@
+variable "project_id" {}
+variable "cluster_name" {}
+variable "region" {}
+variable "network" {}
+variable "subnetwork" {}
+variable "node_count" { default = 1 }
+variable "tags" { type = map(string) }

--- a/service-catalog/gcp/postgres/main.tf
+++ b/service-catalog/gcp/postgres/main.tf
@@ -1,0 +1,24 @@
+module "cloudsql" {
+  source  = "terraform-google-modules/sql-db/google"
+  version = "10.0.0"
+
+  project        = var.project_id
+  name           = var.db_name
+  database_version = "POSTGRES_15"
+  region         = var.region
+
+  settings = {
+    tier             = var.tier
+    backup_configuration = {
+      enabled = true
+      start_time = "02:00"
+    }
+    ip_configuration = {
+      ipv4_enabled = true
+    }
+  }
+
+  root_password = var.admin_password
+
+  tags = var.tags
+}

--- a/service-catalog/gcp/postgres/variables.tf
+++ b/service-catalog/gcp/postgres/variables.tf
@@ -1,0 +1,6 @@
+variable "project_id" {}
+variable "db_name" {}
+variable "region" {}
+variable "tier" { default = "db-custom-1-3840" }
+variable "admin_password" {}
+variable "tags" { type = map(string) }


### PR DESCRIPTION
- Added new Terraform module skeletons:
  - Azure Database for PostgreSQL (service-catalog/azure/postgres)
  - Cloud SQL for PostgreSQL on GCP (service-catalog/gcp/postgres)
- Expanded service mapping (mapping.json) to support managed_postgres_db across AWS, Azure, and GCP
- Enhanced FastAPI backend (main.py):
  - Added dynamic estimated cost calculation based on pricing.json
  - Suggested default region per selected cloud using regions.json
  - Cleanly loads pricing and region data once at startup for performance
- Improved Jinja2 templates:
  - Display estimated monthly cost and default deployment region on result page
- UI improvements:
  - Added dropdowns for cloud platform and service selection
  - Input fields for cluster name and DB identifier
- Keeps architecture modular and ready for dynamic multi-cloud codegen
- Sets solid baseline before integrating live pricing APIs
